### PR TITLE
More Features

### DIFF
--- a/decentralized_identity_system/contracts/decentralized_identity.clar
+++ b/decentralized_identity_system/contracts/decentralized_identity.clar
@@ -204,3 +204,31 @@
     achievement-points: uint
   }
 )
+
+;; Badge System
+(define-public (earn-badge
+  (badge-type (string-ascii 50))
+  (badge-level uint)
+)
+  (let 
+    ((current-did (unwrap! 
+      (map-get? did-registry { did: tx-sender }) 
+      ERR-NOT-FOUND
+    ))
+     (current-reputation (get reputation-score current-did))
+    )
+    (asserts! (>= current-reputation (* badge-level u10)) ERR-INSUFFICIENT-REPUTATION)
+    
+    (map-set did-badges
+      { 
+        did: tx-sender, 
+        badge-type: badge-type 
+      }
+      {
+        earned-timestamp: stacks-block-height,
+        badge-level: badge-level
+      }
+    )
+    (ok true)
+  )
+)

--- a/decentralized_identity_system/contracts/decentralized_identity.clar
+++ b/decentralized_identity_system/contracts/decentralized_identity.clar
@@ -184,3 +184,13 @@
   )
 )
 
+(define-map did-badges
+  { 
+    did: principal, 
+    badge-type: (string-ascii 50) 
+  }
+  {
+    earned-timestamp: uint,
+    badge-level: uint
+  }
+)

--- a/decentralized_identity_system/contracts/decentralized_identity.clar
+++ b/decentralized_identity_system/contracts/decentralized_identity.clar
@@ -281,3 +281,16 @@
     (ok decayed-score)
   )
 )
+
+;; Read-only Functions
+(define-read-only (get-did-badges 
+  (did principal)
+  (badge-type (string-ascii 50))
+)
+  (map-get? did-badges 
+    { 
+      did: did, 
+      badge-type: badge-type 
+    }
+  )
+)

--- a/decentralized_identity_system/contracts/decentralized_identity.clar
+++ b/decentralized_identity_system/contracts/decentralized_identity.clar
@@ -258,3 +258,26 @@
     (ok true)
   )
 )
+
+;; Reputation Decay Mechanism
+(define-public (apply-reputation-decay)
+  (let 
+    ((current-did (unwrap! 
+      (map-get? did-registry { did: tx-sender }) 
+      ERR-NOT-FOUND
+    ))
+     (current-score (get reputation-score current-did))
+     (decayed-score 
+       (if (> current-score u10) 
+           (- current-score u10) 
+           u0
+       )
+    )
+  )
+    (map-set did-registry 
+      { did: tx-sender }
+      (merge current-did { reputation-score: decayed-score })
+    )
+    (ok decayed-score)
+  )
+)

--- a/decentralized_identity_system/contracts/decentralized_identity.clar
+++ b/decentralized_identity_system/contracts/decentralized_identity.clar
@@ -7,6 +7,10 @@
 (define-constant ERR-INVALID-SIGNATURE (err u4))
 (define-constant ERR-MAX-CONNECTIONS (err u5))
 
+(define-constant ERR-INSUFFICIENT-REPUTATION (err u6))
+(define-constant ERR-CLAIM-ALREADY-EXISTS (err u7))
+(define-constant MAX-REPUTATION-SCORE u1000)
+
 ;; DID Registry Map
 (define-map did-registry 
   { did: principal }
@@ -179,3 +183,4 @@
     (ok true)
   )
 )
+

--- a/decentralized_identity_system/contracts/decentralized_identity.clar
+++ b/decentralized_identity_system/contracts/decentralized_identity.clar
@@ -194,3 +194,13 @@
     badge-level: uint
   }
 )
+
+(define-map did-achievements
+  { 
+    did: principal 
+  }
+  {
+    total-achievements: uint,
+    achievement-points: uint
+  }
+)

--- a/decentralized_identity_system/contracts/decentralized_identity.clar
+++ b/decentralized_identity_system/contracts/decentralized_identity.clar
@@ -232,3 +232,29 @@
     (ok true)
   )
 )
+
+
+;; Achievement Tracking
+(define-public (log-achievement
+  (achievement-points uint)
+)
+  (let 
+    ((current-achievements 
+      (default-to 
+        { total-achievements: u0, achievement-points: u0 }
+        (map-get? did-achievements { did: tx-sender })
+      ))
+     (updated-achievements 
+      {
+        total-achievements: (+ (get total-achievements current-achievements) u1),
+        achievement-points: (+ (get achievement-points current-achievements) achievement-points)
+      }
+    ))
+    (map-set did-achievements 
+      { did: tx-sender }
+      updated-achievements
+    )
+    (try! (update-reputation-score achievement-points))
+    (ok true)
+  )
+)

--- a/decentralized_identity_system/contracts/decentralized_identity.clar
+++ b/decentralized_identity_system/contracts/decentralized_identity.clar
@@ -294,3 +294,24 @@
     }
   )
 )
+
+(define-read-only (get-did-achievements (did principal))
+  (map-get? did-achievements { did: did })
+)
+
+;; New Admin Function: Revoke Badge
+(define-public (admin-revoke-badge
+  (did principal)
+  (badge-type (string-ascii 50))
+)
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-UNAUTHORIZED)
+    (map-delete did-badges 
+      { 
+        did: did, 
+        badge-type: badge-type 
+      }
+    )
+    (ok true)
+  )
+)


### PR DESCRIPTION
## Pull Request: Badge System, Achievement Tracking, and Reputation Decay Mechanism

### Summary

This pull request introduces several important updates and features to the system, including a badge system, achievement tracking, a reputation decay mechanism, and an admin function to revoke badges. These changes enhance the user experience and ensure more dynamic interaction within the DID registry. The following key components were added:

- **New constants for error handling and limits**: 
  - `ERR-INSUFFICIENT-REPUTATION` (error code for insufficient reputation).
  - `ERR-CLAIM-ALREADY-EXISTS` (error code for duplicate claims).
  - `MAX-REPUTATION-SCORE` (constant for maximum reputation score).

- **DID Registry Maps**:
  - `did-registry`: Registers DIDs with principals.
  - `did-badges`: Tracks badges associated with DIDs.
  - `did-achievements`: Tracks achievements and points for each DID.

- **Badge System**:
  - `earn-badge`: A public function to allow users to earn badges based on their reputation score. The badge is only awarded if the user has a sufficient reputation.

- **Achievement Tracking**:
  - `log-achievement`: A public function to log achievements for a DID, updating both the total achievements and achievement points.

- **Reputation Decay**:
  - `apply-reputation-decay`: A public function that decreases a user's reputation score by 10 units. The reputation decay ensures the system remains dynamic.

- **Read-only Functions**:
  - `get-did-badges`: Allows querying a user's badges.
  - `get-did-achievements`: Allows querying a user's achievements.

- **Admin Function - Revoke Badge**:
  - `admin-revoke-badge`: An administrative function to revoke a badge from a DID. The function is restricted to the contract owner.

### Changes

#### Constants

```clojure
(define-constant ERR-INSUFFICIENT-REPUTATION (err u6))
(define-constant ERR-CLAIM-ALREADY-EXISTS (err u7))
(define-constant MAX-REPUTATION-SCORE u1000)
```

#### DID Registry Maps

```clojure
(define-map did-registry 
  { did: principal }
  { }
)

(define-map did-badges
  { 
    did: principal, 
    badge-type: (string-ascii 50) 
  }
  {
    earned-timestamp: uint,
    badge-level: uint
  }
)

(define-map did-achievements
  { 
    did: principal 
  }
  {
    total-achievements: uint,
    achievement-points: uint
  }
)
```

#### Badge System

```clojure
(define-public (earn-badge
  (badge-type (string-ascii 50))
  (badge-level uint)
)
  (let 
    ((current-did (unwrap! 
      (map-get? did-registry { did: tx-sender }) 
      ERR-NOT-FOUND
    ))
     (current-reputation (get reputation-score current-did))
    )
    (asserts! (>= current-reputation (* badge-level u10)) ERR-INSUFFICIENT-REPUTATION)

    (map-set did-badges
      { 
        did: tx-sender, 
        badge-type: badge-type 
      }
      {
        earned-timestamp: stacks-block-height,
        badge-level: badge-level
      }
    )
    (ok true)
  )
)
```

#### Achievement Tracking

```clojure
(define-public (log-achievement
  (achievement-points uint)
)
  (let 
    ((current-achievements 
      (default-to 
        { total-achievements: u0, achievement-points: u0 }
        (map-get? did-achievements { did: tx-sender })
      )))
     (updated-achievements 
      {
        total-achievements: (+ (get total-achievements current-achievements) u1),
        achievement-points: (+ (get achievement-points current-achievements) achievement-points)
      }
    ))
    (map-set did-achievements 
      { did: tx-sender }
      updated-achievements
    )
    (try! (update-reputation-score achievement-points))
    (ok true)
  )
)
```

#### Reputation Decay Mechanism

```clojure
(define-public (apply-reputation-decay)
  (let 
    ((current-did (unwrap! 
      (map-get? did-registry { did: tx-sender }) 
      ERR-NOT-FOUND
    ))
     (current-score (get reputation-score current-did))
     (decayed-score 
       (if (> current-score u10) 
           (- current-score u10) 
           u0
       )
    )
  )
    (map-set did-registry 
      { did: tx-sender }
      (merge current-did { reputation-score: decayed-score })
    )
    (ok decayed-score)
  )
)
```

#### Read-only Functions

```clojure
(define-read-only (get-did-badges 
  (did principal)
  (badge-type (string-ascii 50))
)
  (map-get? did-badges 
    { 
      did: did, 
      badge-type: badge-type 
    }
  )
)

(define-read-only (get-did-achievements (did principal))
  (map-get? did-achievements { did: did })
)
```

#### Admin Function: Revoke Badge

```clojure
(define-public (admin-revoke-badge
  (did principal)
  (badge-type (string-ascii 50))
)
  (begin
    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-UNAUTHORIZED)
    (map-delete did-badges 
      { 
        did: did, 
        badge-type: badge-type 
      }
    )
    (ok true)
  )
)
```

### Related Issues

- Implement badge and achievement tracking for better user interaction.
- Introduce a reputation decay mechanism to manage the lifespan of reputation scores.